### PR TITLE
fix expiring in redis increment

### DIFF
--- a/src/Core/Tests/Caching/CacheClientTestsBase.cs
+++ b/src/Core/Tests/Caching/CacheClientTestsBase.cs
@@ -293,6 +293,27 @@ namespace Foundatio.Tests.Caching {
             }
         }
 
+        public virtual async Task CanIncrementAndExpire() {
+            var cache = GetCacheClient();
+            if (cache == null)
+                return;
+
+            using (cache) {
+                await cache.RemoveAllAsync();
+
+                var success = await cache.SetAsync("test", 0);
+                Assert.True(success);
+
+                var expiresIn = TimeSpan.FromSeconds(1);
+                var newVal = await cache.IncrementAsync("test", 1, expiresIn);
+
+                Assert.Equal(1, newVal);
+
+                await Task.Delay(1500);
+                Assert.False((await cache.GetAsync<int>("test")).HasValue);
+            }
+        }
+
         public virtual async Task MeasureThroughput() {
             var cacheClient = GetCacheClient();
             if (cacheClient == null)

--- a/src/Core/Tests/Caching/HybridCacheClientTests.cs
+++ b/src/Core/Tests/Caching/HybridCacheClientTests.cs
@@ -62,6 +62,11 @@ namespace Foundatio.Tests.Caching {
         }
 
         [Fact]
+        public override Task CanIncrementAndExpire() {
+            return base.CanIncrementAndExpire();
+        }
+
+        [Fact]
         public virtual async Task WillUseLocalCache() {
             var firstCache = GetCacheClient() as HybridCacheClient;
             Assert.NotNull(firstCache);

--- a/src/Core/Tests/Caching/InMemoryCacheClientTests.cs
+++ b/src/Core/Tests/Caching/InMemoryCacheClientTests.cs
@@ -54,6 +54,11 @@ namespace Foundatio.Tests.Caching {
         }
 
         [Fact]
+        public override Task CanIncrementAndExpire() {
+            return base.CanIncrementAndExpire();
+        }
+
+        [Fact]
         public async Task CanSetMaxItems() {
             // run in tight loop so that the code is warmed up and we can catch timing issues
             for (int x = 0; x < 5; x++) {

--- a/src/Redis/Tests/Caching/RedisCacheClientTests.cs
+++ b/src/Redis/Tests/Caching/RedisCacheClientTests.cs
@@ -48,6 +48,11 @@ namespace Foundatio.Redis.Tests.Caching {
             return base.CanSetExpiration();
         }
 
+        [Fact]
+        public override Task CanIncrementAndExpire() {
+            return base.CanIncrementAndExpire();
+        }
+
 
         [Fact]
         public override Task CanRemoveByPrefix() {


### PR DESCRIPTION
In LM we are using the ThrottlingLockProvider with redis cache client.. 
Our keys were not expiring because the lua script was never hitting the expire command.

Also, redis can only handle whole seconds when using `expire`, so I modified the the lua scripts to round it up if what you sent in is a fraction of a second.

I added some tests..  but they take a few seconds to run since redis can only expire after a second. Maybe they are not worth it? Let me know