### PR TITLE
rabbitmq delayed message exchange

### DIFF
--- a/samples/Foundatio.RabbitMQPublishConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQPublishConsole/Program.cs
@@ -7,26 +7,16 @@ namespace Foundatio.RabbitMQPublishConsole {
             IMessageBus messageBus;
             string message;
             Console.WriteLine("Publisher...");
+            messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                    "FoundatioExchange", true, true, false, false);
 
-            Console.WriteLine("Enter 1 for delayed exchange type , 2 for regular exchange type. Hit Enter.");
-            var exchangeType = Console.ReadLine();
-            if (string.Equals(exchangeType, "1")) {
-                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                    "FoundatioDelayedExchange", true, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
-                
-            } else {
-                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                    "FoundatioExchange", false, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
-            }
             Console.WriteLine("Enter the messages to send (press CTRL+Z) to exit :");
+
             do {
                 message = Console.ReadLine();
-                if (string.Equals(exchangeType, "1")) {
-                    messageBus.PublishAsync(message/*, TimeSpan.FromMilliseconds(60000)*/);
-                } else {
                     messageBus.PublishAsync(message);
-                }
             } while (message != null);
+
             messageBus.Dispose();
         }
     }

--- a/samples/Foundatio.RabbitMQPublishConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQPublishConsole/Program.cs
@@ -4,14 +4,29 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQPublishConsole {
     public class Program {
         public static void Main(string[] args) {
-            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
-            string input;
+            IMessageBus messageBus;
+            string message;
             Console.WriteLine("Publisher...");
+
+            Console.WriteLine("Enter 1 for delayed exchange type , 2 for regular exchange type. Hit Enter.");
+            var exchangeType = Console.ReadLine();
+            if (string.Equals(exchangeType, "1")) {
+                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                    "FoundatioDelayedExchange", true, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+                
+            } else {
+                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                    "FoundatioExchange", false, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+            }
             Console.WriteLine("Enter the messages to send (press CTRL+Z) to exit :");
             do {
-                input = Console.ReadLine();
-                messageBus.PublishAsync(input, TimeSpan.FromMilliseconds(60000));
-            } while (input != null);
+                message = Console.ReadLine();
+                if (string.Equals(exchangeType, "1")) {
+                    messageBus.PublishAsync(message/*, TimeSpan.FromMilliseconds(60000)*/);
+                } else {
+                    messageBus.PublishAsync(message);
+                }
+            } while (message != null);
             messageBus.Dispose();
         }
     }

--- a/samples/Foundatio.RabbitMQPublishConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQPublishConsole/Program.cs
@@ -7,8 +7,7 @@ namespace Foundatio.RabbitMQPublishConsole {
             IMessageBus messageBus;
             string message;
             Console.WriteLine("Publisher...");
-            messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                    "FoundatioExchange", true, true, false, false);
+            messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioExchangeFanout", "FoundatioExchangeFanoutQueue");
 
             Console.WriteLine("Enter the messages to send (press CTRL+Z) to exit :");
 

--- a/samples/Foundatio.RabbitMQPublishConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQPublishConsole/Program.cs
@@ -4,13 +4,13 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQPublishConsole {
     public class Program {
         public static void Main(string[] args) {
-            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
             string input;
             Console.WriteLine("Publisher...");
             Console.WriteLine("Enter the messages to send (press CTRL+Z) to exit :");
             do {
                 input = Console.ReadLine();
-                messageBus.PublishAsync(input);
+                messageBus.PublishAsync(input, TimeSpan.FromMilliseconds(60000));
             } while (input != null);
             messageBus.Dispose();
         }

--- a/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
@@ -4,19 +4,9 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQSubscribeConsole {
     public class Program {
         public static void Main(string[] args) {
-            IMessageBus messageBus;
             Console.WriteLine("Subscriber....");
-
-            Console.WriteLine("Enter 1 for delayed exchange type , 2 for regular exchange type");
-            var exchangeType = Console.ReadLine();
-            if (string.Equals(exchangeType, "1")) {
-                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                    "FoundatioDelayedExchange", true, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
-
-            } else {
-                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                    "FoundatioExchange", false, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
-            }
+            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                "FoundatioExchange", true, true, false, false);
 
             messageBus.Subscribe<string>(msg => { Console.WriteLine(msg); });
             Console.ReadLine();

--- a/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
@@ -4,9 +4,8 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQSubscribeConsole {
     public class Program {
         public static void Main(string[] args) {
-            Console.WriteLine("Subscriber....");
-            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                "FoundatioExchange", true, true, false, false);
+            Console.WriteLine("Subscriber...." +  args[0]);
+            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioExchangeFanout", args[0]);
 
             messageBus.Subscribe<string>(msg => { Console.WriteLine(msg); });
             Console.ReadLine();

--- a/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
@@ -4,7 +4,7 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQSubscribeConsole {
     public class Program {
         public static void Main(string[] args) {
-            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
             Console.WriteLine("Subscriber....");
             messageBus.Subscribe<string>(msg => { Console.WriteLine(msg); });
             Console.ReadLine();

--- a/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
+++ b/samples/Foundatio.RabbitMQSubscribeConsole/Program.cs
@@ -4,8 +4,20 @@ using Foundatio.Messaging;
 namespace Foundatio.RabbitMQSubscribeConsole {
     public class Program {
         public static void Main(string[] args) {
-            IMessageBus messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+            IMessageBus messageBus;
             Console.WriteLine("Subscriber....");
+
+            Console.WriteLine("Enter 1 for delayed exchange type , 2 for regular exchange type");
+            var exchangeType = Console.ReadLine();
+            if (string.Equals(exchangeType, "1")) {
+                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                    "FoundatioDelayedExchange", true, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+
+            } else {
+                messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                    "FoundatioExchange", false, true, true, false, false, null, TimeSpan.FromMilliseconds(50));
+            }
+
             messageBus.Subscribe<string>(msg => { Console.WriteLine(msg); });
             Console.ReadLine();
         }

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Extensions;
@@ -137,7 +138,7 @@ namespace Foundatio.Messaging {
             
             var basicProperties = _publisherChannel.CreateBasicProperties();
             basicProperties.Persistent = _persistent;
-            basicProperties.Expiration = _defaultMessageTimeToLive.Milliseconds.ToString();
+            basicProperties.Expiration = _defaultMessageTimeToLive.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
             // RabbitMQ only supports delayed messages with a third party plugin called "rabbitmq_delayed_message_exchange"
             if (_delayedExchange && delay.HasValue && delay.Value > TimeSpan.Zero) {
                 // Its necessary to typecast long to int because rabbitmq on the consumer side is reading the 

--- a/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
+++ b/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
@@ -14,8 +14,8 @@ namespace Foundatio.RabbitMQ.Tests.Messaging {
             if (_messageBus != null)
                 return _messageBus;
 
-            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioExchange", false, true, true,
-                false, false, null, TimeSpan.FromMilliseconds(50), loggerFactory: Log);
+            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
+                "FoundatioExchange", true, true, false, false);
             return _messageBus;
         }
 

--- a/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
+++ b/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
@@ -14,8 +14,7 @@ namespace Foundatio.RabbitMQ.Tests.Messaging {
             if (_messageBus != null)
                 return _messageBus;
 
-            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey",
-                "FoundatioExchange", true, true, false, false);
+            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioExchangeFanout", "FoundatioExchangeFanoutQueue");
             return _messageBus;
         }
 

--- a/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
+++ b/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
@@ -14,7 +14,7 @@ namespace Foundatio.RabbitMQ.Tests.Messaging {
             if (_messageBus != null)
                 return _messageBus;
 
-            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioExchange", true, true,
+            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true,
                 false, false, null, TimeSpan.FromMilliseconds(50), loggerFactory: Log);
             return _messageBus;
         }

--- a/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
+++ b/test/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTests.cs
@@ -14,7 +14,7 @@ namespace Foundatio.RabbitMQ.Tests.Messaging {
             if (_messageBus != null)
                 return _messageBus;
 
-            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioDelayedExchange", true, true,
+            _messageBus = new RabbitMQMessageBus("guest", "guest", "FoundatioQueue", "FoundatioQueueRoutingKey", "FoundatioExchange", false, true, true,
                 false, false, null, TimeSpan.FromMilliseconds(50), loggerFactory: Log);
             return _messageBus;
         }

--- a/test/Foundatio.Tests/Messaging/MessageBusTestBase.cs
+++ b/test/Foundatio.Tests/Messaging/MessageBusTestBase.cs
@@ -8,8 +8,8 @@ using Foundatio.Tests.Extensions;
 using Foundatio.Logging;
 using Foundatio.Logging.Xunit;
 using Foundatio.Messaging;
-using Xunit;
 using Foundatio.Utility;
+using Xunit;
 using Nito.AsyncEx;
 using Xunit.Abstractions;
 
@@ -36,8 +36,7 @@ namespace Foundatio.Tests.Messaging {
                     resetEvent.Set();
                     _logger.Trace("Set event");
                 });
-
-                await SystemClock.SleepAsync(100);
+                
                 await messageBus.PublishAsync(new SimpleMessageA {
                     Data = "Hello"
                 });
@@ -58,12 +57,11 @@ namespace Foundatio.Tests.Messaging {
                     resetEvent.Set();
                     throw new Exception();
                 });
-
-                await SystemClock.SleepAsync(100);
+                
                 await messageBus.PublishAsync<object>(null);
                 _logger.Trace("Published one...");
 
-                await resetEvent.WaitAsync(TimeSpan.FromSeconds(1));
+                await Assert.ThrowsAsync<TaskCanceledException>(async () => await resetEvent.WaitAsync(TimeSpan.FromMilliseconds(250)));
             }
         }
         
@@ -80,8 +78,7 @@ namespace Foundatio.Tests.Messaging {
                     resetEvent.Set();
                     _logger.Trace("Set event");
                 });
-
-                await SystemClock.SleepAsync(100);
+                
                 await messageBus.PublishAsync(new DerivedSimpleMessageA {
                     Data = "Hello"
                 });

--- a/test/Foundatio.Tests/Queue/QueueTestBase.cs
+++ b/test/Foundatio.Tests/Queue/QueueTestBase.cs
@@ -118,7 +118,7 @@ namespace Foundatio.Tests.Queue {
 
                     Assert.InRange(sw.ElapsedMilliseconds, iterations * 10, iterations * 50);
                     var timing = await metrics.GetTimerStatsAsync("simpleworkitem.queuetime");
-                    Assert.InRange(timing.AverageDuration, 0, 25);
+                    Assert.InRange(timing.AverageDuration, 0, 30);
                 }
             }
         }

--- a/test/Foundatio.Tests/Storage/FileStorageTestsBase.cs
+++ b/test/Foundatio.Tests/Storage/FileStorageTestsBase.cs
@@ -175,6 +175,15 @@ namespace Foundatio.Tests.Storage {
                 });
             }
         }
+        
+        public virtual void CanUseDataDirectory() {
+            const string DATA_DIRECTORY_QUEUE_FOLDER = @"|DataDirectory|\Queue";
+
+            var storage = new FolderFileStorage(DATA_DIRECTORY_QUEUE_FOLDER);
+            Assert.NotNull(storage.Folder);
+            Assert.NotEqual(DATA_DIRECTORY_QUEUE_FOLDER, storage.Folder);
+            Assert.True(storage.Folder.EndsWith("Queue\\"), storage.Folder);
+        }
     }
 
     public class PostInfo {

--- a/test/Foundatio.Tests/Storage/FolderFileStorageTests.cs
+++ b/test/Foundatio.Tests/Storage/FolderFileStorageTests.cs
@@ -5,8 +5,6 @@ using Xunit.Abstractions;
 
 namespace Foundatio.Tests.Storage {
     public class FolderFileStorageTests : FileStorageTestsBase {
-        private const string DATA_DIRECTORY_QUEUE_FOLDER = @"|DataDirectory|\Queue";
-
         public FolderFileStorageTests(ITestOutputHelper output) : base(output) {}
 
         protected override IFileStorage GetStorage() {
@@ -37,13 +35,12 @@ namespace Foundatio.Tests.Storage {
         public override Task CanConcurrentlyManageFiles() {
             return base.CanConcurrentlyManageFiles();
         }
-
+        
+#if !NETSTANDARD
         [Fact]
-        public void CanUseDataDirectory() {
-            var storage = new FolderFileStorage(DATA_DIRECTORY_QUEUE_FOLDER);
-            Assert.NotNull(storage.Folder);
-            Assert.NotEqual(DATA_DIRECTORY_QUEUE_FOLDER, storage.Folder);
-            Assert.True(storage.Folder.EndsWith("Queue\\"), storage.Folder);
+        public override void CanUseDataDirectory() {
+            base.CanUseDataDirectory();
         }
+#endif
     }
 }

--- a/test/Foundatio.Tests/Storage/ScopedFolderFileStorageTests.cs
+++ b/test/Foundatio.Tests/Storage/ScopedFolderFileStorageTests.cs
@@ -5,8 +5,6 @@ using Xunit.Abstractions;
 
 namespace Foundatio.Tests.Storage {
     public class ScopedFolderFileStorageTests : FileStorageTestsBase {
-        private const string DATA_DIRECTORY_QUEUE_FOLDER = @"|DataDirectory|\Queue";
-
         public ScopedFolderFileStorageTests(ITestOutputHelper output) : base(output) {}
 
         protected override IFileStorage GetStorage() {
@@ -38,12 +36,11 @@ namespace Foundatio.Tests.Storage {
             return base.CanConcurrentlyManageFiles();
         }
 
+#if !NETSTANDARD
         [Fact]
-        public void CanUseDataDirectory() {
-            var storage = new FolderFileStorage(DATA_DIRECTORY_QUEUE_FOLDER);
-            Assert.NotNull(storage.Folder);
-            Assert.NotEqual(DATA_DIRECTORY_QUEUE_FOLDER, storage.Folder);
-            Assert.True(storage.Folder.EndsWith("Queue\\"), storage.Folder);
+        public override void CanUseDataDirectory() {
+            base.CanUseDataDirectory();
         }
+#endif
     }
 }

--- a/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
+++ b/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
@@ -46,10 +46,11 @@ namespace Foundatio.Tests.Utility {
             };
 
             using (var timer = new ScheduledTimer(callback, loggerFactory: Log)) {
-                timer.ScheduleNext();
-                timer.ScheduleNext(SystemClock.UtcNow.AddMilliseconds(20));
-                timer.ScheduleNext(SystemClock.UtcNow.AddMilliseconds(40));
-                
+                for (int i = 0; i < 4; i++) {
+                    timer.ScheduleNext();
+                    SystemClock.Sleep(1);
+                }
+
                 await countdown.WaitAsync(TimeSpan.FromMilliseconds(100));
                 Assert.Equal(1, countdown.CurrentCount);
                 

--- a/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
+++ b/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
@@ -13,13 +13,12 @@ using Xunit.Abstractions;
 namespace Foundatio.Tests.Utility {
     public class ScheduledTimerTests : TestWithLoggingBase {
         public ScheduledTimerTests(ITestOutputHelper output) : base(output) {
+            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
             SystemClock.Reset();
         }
 
         [Fact]
         public async Task CanRun() {
-            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
-
             int hits = 0;
             Func<Task<DateTime?>> callback = async () => {
                 Interlocked.Increment(ref hits);
@@ -36,7 +35,6 @@ namespace Foundatio.Tests.Utility {
 
         [Fact]
         public async Task CanRunAndScheduleConcurrently() {
-            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
             var countdown = new AsyncCountdownEvent(2);
             
             Func<Task<DateTime?>> callback = async () => {
@@ -49,8 +47,8 @@ namespace Foundatio.Tests.Utility {
 
             using (var timer = new ScheduledTimer(callback, loggerFactory: Log)) {
                 timer.ScheduleNext();
-                timer.ScheduleNext(SystemClock.UtcNow.AddMilliseconds(10));
                 timer.ScheduleNext(SystemClock.UtcNow.AddMilliseconds(20));
+                timer.ScheduleNext(SystemClock.UtcNow.AddMilliseconds(40));
                 
                 await countdown.WaitAsync(TimeSpan.FromMilliseconds(100));
                 Assert.Equal(1, countdown.CurrentCount);
@@ -62,7 +60,6 @@ namespace Foundatio.Tests.Utility {
 
         [Fact]
         public async Task CanRunWithMinimumInterval() {
-            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
             var resetEvent = new AsyncAutoResetEvent(false);
             
             int hits = 0;
@@ -94,7 +91,6 @@ namespace Foundatio.Tests.Utility {
         
         [Fact]
         public async Task CanRecoverFromError() {
-            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
             var resetEvent = new AsyncAutoResetEvent(false);
 
             int hits = 0;
@@ -118,8 +114,6 @@ namespace Foundatio.Tests.Utility {
 
         [Fact]
         public async Task CanRunConcurrent() {
-            Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
-
             int hits = 0;
             Func<Task<DateTime?>> callback = () => {
                 int i = Interlocked.Increment(ref hits);

--- a/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
+++ b/test/Foundatio.Tests/Utility/ScheduledTimerTests.cs
@@ -19,17 +19,16 @@ namespace Foundatio.Tests.Utility {
 
         [Fact]
         public async Task CanRun() {
-            int hits = 0;
-            Func<Task<DateTime?>> callback = async () => {
-                Interlocked.Increment(ref hits);
-                await SystemClock.SleepAsync(50);
+            var countdown = new AsyncCountdownEvent(1);
+            Func<Task<DateTime?>> callback = () => {
+                countdown.Signal();
                 return null;
             };
 
             using (var timer = new ScheduledTimer(callback, loggerFactory: Log)) {
                 timer.ScheduleNext();
-                await SystemClock.SleepAsync(50);
-                Assert.Equal(1, hits);
+                await countdown.WaitAsync(TimeSpan.FromMilliseconds(100));
+                Assert.Equal(0, countdown.CurrentCount);
             }
         }
 
@@ -61,32 +60,27 @@ namespace Foundatio.Tests.Utility {
 
         [Fact]
         public async Task CanRunWithMinimumInterval() {
-            var resetEvent = new AsyncAutoResetEvent(false);
-            
-            int hits = 0;
-            Func<Task<DateTime?>> callback = () => {
-                Interlocked.Increment(ref hits);
-                _logger.Info($"hits: {hits}");
-                resetEvent.Set();
-                return Task.FromResult<DateTime?>(null);
+            var countdown = new AsyncCountdownEvent(2);
+
+            Func<Task<DateTime?>> callback = async () => {
+                _logger.Info("Starting work.");
+                countdown.Signal();
+                await SystemClock.SleepAsync(500);
+                _logger.Info("Finished work.");
+                return null;
             };
-            
+
             using (var timer = new ScheduledTimer(callback, minimumIntervalTime: TimeSpan.FromMilliseconds(100), loggerFactory: Log)) {
-                var sw = Stopwatch.StartNew();
-                timer.ScheduleNext();
-                await SystemClock.SleepAsync(1);
-                timer.ScheduleNext();
-                await SystemClock.SleepAsync(1);
-                timer.ScheduleNext();
+                for (int i = 0; i < 4; i++) {
+                    timer.ScheduleNext();
+                    SystemClock.Sleep(1);
+                }
 
-                await resetEvent.WaitAsync(new CancellationTokenSource(100).Token);
-                Assert.InRange(hits, 1, 2);
-                
-                await resetEvent.WaitAsync(new CancellationTokenSource(2000).Token);
-                sw.Stop();
+                await countdown.WaitAsync(TimeSpan.FromMilliseconds(100));
+                Assert.Equal(1, countdown.CurrentCount);
 
-                Assert.InRange(hits, 2, 3);
-                Assert.InRange(sw.ElapsedMilliseconds, 100, 2000);
+                await countdown.WaitAsync(TimeSpan.FromSeconds(1.5));
+                Assert.Equal(0, countdown.CurrentCount);
             }
         }
         
@@ -109,30 +103,6 @@ namespace Foundatio.Tests.Utility {
                 timer.ScheduleNext();
 
                 await resetEvent.WaitAsync(new CancellationTokenSource(500).Token);
-                Assert.Equal(2, hits);
-            }
-        }
-
-        [Fact]
-        public async Task CanRunConcurrent() {
-            int hits = 0;
-            Func<Task<DateTime?>> callback = () => {
-                int i = Interlocked.Increment(ref hits);
-                _logger.Info($"Running {i}...");
-                return Task.FromResult<DateTime?>(null);
-            };
-
-            using (var timer = new ScheduledTimer(callback, minimumIntervalTime: TimeSpan.FromMilliseconds(100), loggerFactory: Log)) {
-                for (int i = 1; i <= 5; i++) {
-                    _logger.Info($"Scheduling #{i}");
-                    timer.ScheduleNext();
-                    await SystemClock.SleepAsync(5);
-                }
-
-                await SystemClock.SleepAsync(250);
-                Assert.Equal(2, hits);
-
-                await SystemClock.SleepAsync(100);
                 Assert.Equal(2, hits);
             }
         }


### PR DESCRIPTION
This change implements rabbitmq delayed message exchange. You will be required to enable the plugin rabbitmq_delayed_message_exchange. Added a member in the constructor that decides if the user wants to create and actual exchange or the delayed exchange.