### PR TITLE
Cache all values in the local cache rather than just the serialized ones.

### DIFF
--- a/src/Foundatio/Caching/HybridCacheClient.cs
+++ b/src/Foundatio/Caching/HybridCacheClient.cs
@@ -86,8 +86,6 @@ namespace Foundatio.Caching {
 
         public async Task<CacheValue<T>> GetAsync<T>(string key) {
             CacheValue<T> cacheValue;
-            bool requiresSerialization = TypeRequiresSerialization(typeof(T));
-            _logger.Trace("Type requires serialization: {0}", requiresSerialization);
             
             cacheValue = await _localCache.GetAsync<T>(key).AnyContext();
             if (cacheValue.HasValue) {
@@ -187,9 +185,7 @@ namespace Foundatio.Caching {
 
         public async Task<CacheValue<ICollection<T>>> GetSetAsync<T>(string key) {
             CacheValue<ICollection<T>> cacheValue;
-            bool requiresSerialization = TypeRequiresSerialization(typeof(T));
-            _logger.Trace("Type requires serialization: {0}", requiresSerialization);
-
+           
             cacheValue = await _localCache.GetSetAsync<T>(key).AnyContext();
             if (cacheValue.HasValue) {
                 _logger.Trace("Local cache hit: {0}", key);
@@ -208,13 +204,6 @@ namespace Foundatio.Caching {
             }
 
             return cacheValue.HasValue ? cacheValue : CacheValue<ICollection<T>>.NoValue;
-        }
-
-        private bool TypeRequiresSerialization(Type t) {
-            if (t == TypeHelper.BoolType || t == TypeHelper.ByteArrayType || t == TypeHelper.StringType || t.IsNumeric() || t.IsNullableNumeric())
-                return false;
-
-            return true;
         }
 
         public virtual void Dispose() {

--- a/test/Foundatio.Tests/Caching/HybridCacheClientTests.cs
+++ b/test/Foundatio.Tests/Caching/HybridCacheClientTests.cs
@@ -80,18 +80,17 @@ namespace Foundatio.Tests.Caching {
 
                     await firstCache.SetAsync("first1", 1);
                     await firstCache.IncrementAsync("first2");
-                    // doesnt use localcache for simple types
-                    Assert.Equal(0, firstCache.LocalCache.Count);
+                    Assert.Equal(1, firstCache.LocalCache.Count);
 
                     var cacheKey = Guid.NewGuid().ToString("N").Substring(10);
                     await firstCache.SetAsync(cacheKey, new SimpleModel { Data1 = "test" });
-                    Assert.Equal(1, firstCache.LocalCache.Count);
+                    Assert.Equal(2, firstCache.LocalCache.Count);
                     Assert.Equal(0, secondCache.LocalCache.Count);
                     Assert.Equal(0, firstCache.LocalCacheHits);
 
                     Assert.True((await firstCache.GetAsync<SimpleModel>(cacheKey)).HasValue);
                     Assert.Equal(1, firstCache.LocalCacheHits);
-                    Assert.Equal(1, firstCache.LocalCache.Count);
+                    Assert.Equal(2, firstCache.LocalCache.Count);
 
                     Assert.True((await secondCache.GetAsync<SimpleModel>(cacheKey)).HasValue);
                     Assert.Equal(0, secondCache.LocalCacheHits);


### PR DESCRIPTION
Cache all values in the local cache rather than just the serialized ones.

Fix test to match counts.
