### PR TITLE
Extension method to ICachingClient for GetOrAddAsync

### DIFF
--- a/src/Foundatio/Caching/CacheClientHelpers.cs
+++ b/src/Foundatio/Caching/CacheClientHelpers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Foundatio.Caching
+{
+    public static class CacheClientHelpers
+    {
+        public static async Task<CacheValue<T>> GetOrAddAsync<T>(this ICacheClient client, string key, Func<T> addFunc,
+            TimeSpan? expiresIn = null)
+        {
+            var cachedValue = await client.GetAsync<T>(key);
+            if (cachedValue.HasValue) return cachedValue;
+
+            var value = addFunc();
+
+            var addResult = await client.AddAsync(key, value, expiresIn);
+            return addResult ? new CacheValue<T>(value, true) : CacheValue<T>.NoValue;
+        }
+    }
+}

--- a/test/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/test/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -72,6 +72,12 @@ namespace Foundatio.Redis.Tests.Caching {
             await base.CanManageSets();
         }
 
+        [Fact]
+        public override Task CanGetOrAddAsync()
+        {
+            return base.CanGetOrAddAsync();
+        }
+
         [Fact(Skip = "Performance Test")]
         public override Task MeasureThroughput() {
             return base.MeasureThroughput();
@@ -86,5 +92,7 @@ namespace Foundatio.Redis.Tests.Caching {
         public override Task MeasureSerializerComplexThroughput() {
             return base.MeasureSerializerComplexThroughput();
         }
+
+        
     }
 }

--- a/test/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/test/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -53,6 +53,12 @@ namespace Foundatio.Redis.Tests.Caching {
         }
 
         [Fact]
+        public override Task CanGetOrAddAsync()
+        {
+            return base.CanGetOrAddAsync();
+        }
+
+        [Fact]
         public override Task WillUseLocalCache() {
             return base.WillUseLocalCache();
         }
@@ -81,5 +87,6 @@ namespace Foundatio.Redis.Tests.Caching {
         public override Task MeasureSerializerComplexThroughput() {
             return base.MeasureSerializerComplexThroughput();
         }
+
     }
 }

--- a/test/Foundatio.Tests/Caching/CacheClientTestsBase.cs
+++ b/test/Foundatio.Tests/Caching/CacheClientTestsBase.cs
@@ -23,6 +23,30 @@ namespace Foundatio.Tests.Caching {
             return null;
         }
 
+        public virtual async Task CanGetOrAddAsync()
+        {
+            var cache = GetCacheClient();
+            if (cache == null)
+                return;
+
+            using (cache)
+            {
+                await cache.RemoveAllAsync();
+
+                var addFunc = new Func<int>(() => 1);
+                var result1 = await cache.GetOrAddAsync("test1", addFunc);
+
+                Assert.NotNull(result1);
+                Assert.Equal(result1.Value, 1);
+
+                var addFunc2 = new Func<int>(() => 2);
+                var result2 = await cache.GetOrAddAsync("test1", addFunc2);
+
+                Assert.NotNull(result2);
+                Assert.Equal(result2.Value, 1);
+            }
+        }
+
         public virtual async Task CanGetAll() {
             var cache = GetCacheClient();
             if (cache == null)

--- a/test/Foundatio.Tests/Caching/HybridCacheClientTests.cs
+++ b/test/Foundatio.Tests/Caching/HybridCacheClientTests.cs
@@ -71,6 +71,12 @@ namespace Foundatio.Tests.Caching {
         }
 
         [Fact]
+        public override Task CanGetOrAddAsync()
+        {
+            return base.CanGetOrAddAsync();
+        }
+
+        [Fact]
         public virtual async Task WillUseLocalCache() {
             using (var firstCache = GetCacheClient() as HybridCacheClient) {
                 Assert.NotNull(firstCache);
@@ -164,6 +170,8 @@ namespace Foundatio.Tests.Caching {
                 }
             }
         }
+
+        
 
         public void Dispose() {
             _distributedCache.Dispose();

--- a/test/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/test/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -65,6 +65,12 @@ namespace Foundatio.Tests.Caching {
         }
 
         [Fact]
+        public override Task CanGetOrAddAsync()
+        {
+            return base.CanGetOrAddAsync();
+        }
+
+        [Fact]
         public async Task CanSetMaxItems() {
             // run in tight loop so that the code is warmed up and we can catch timing issues
             for (int x = 0; x < 5; x++) {


### PR DESCRIPTION
Per recommendation, which I think made way more sense, I added this as an extension method.  Kept all the other tests that I had in place.