### PR TITLE
Update XUnit to 2.2

### DIFF
--- a/src/Foundatio.Logging.Xunit/Foundatio.Logging.Xunit.csproj
+++ b/src/Foundatio.Logging.Xunit/Foundatio.Logging.Xunit.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="xunit.core" Version="2.2.0-rc3-build3528" />
+    <PackageReference Include="xunit.core" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/test/Foundatio.Tests/Foundatio.Tests.csproj
+++ b/test/Foundatio.Tests/Foundatio.Tests.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170210-02" />
-    <PackageReference Include="xunit" Version="2.2.0-rc3-build3528" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-rc3-build1252" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Foundatio.Logging.Xunit\Foundatio.Logging.Xunit.csproj" />


### PR DESCRIPTION
Adds support for `netstandard1.1`